### PR TITLE
Fix uninstall detection on enterprise 3.5.4

### DIFF
--- a/bulk-install-app/install.py
+++ b/bulk-install-app/install.py
@@ -135,10 +135,7 @@ def check_uninstall(uninstall_complete_page):
     """
     Given the resulting uninstall page, check to see if uninstall succeeded.
     """
-    uninstall_complete_page_message = uninstall_complete_page.find(
-        'div', {'class': re.compile('container-lg*', re.IGNORECASE)}
-    )
-    return 'job has been queued to uninstall' in uninstall_complete_page_message.text
+    return 'job has been queued to uninstall' in uninstall_complete_page.text
 
 
 def uninstall(session, target_name: str, target_id: Optional[int] = None, installation_path: Optional[str] = None):


### PR DESCRIPTION
Tested on 3.5.4 after installing the app on 15 organizations. See logs below - 

```
kathy@Kathys-Blu-MBP bulk-install-app % python3 -u main.py --uninstall 2>&1 | tee -a bulk-install-app-results.txt


2022-12-14 17:37:07.388577 - Bulk Uninstall
GitHub App: enterprise-checks-dev-testing, Domain: <domain>, Max Organizations: 15


Two-factor authentication not required.
Succeeded to login for GitHub user: <user>

https://github.blucodon.com/github-apps/enterprise-checks-dev-testing/installations/new
Found organization/user: <user>, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: <user>


Found organization/user: apple, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: apple


Found organization/user: broccoli, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: broccoli


Found organization/user: cauliflower, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: cauliflower


Found organization/user: durian, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: durian


Found organization/user: egg, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: egg


Found organization/user: fig, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: fig


Found organization/user: garlic, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: garlic


Found organization/user: ham, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: ham


Found organization/user: ice, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: ice


Found organization/user: jalapeno, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: jalapeno


Found organization/user: kale, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: kale


Found organization/user: lemon, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: lemon


Found organization/user: mango, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: mango


Found organization/user: nectarine, to uninstall app: enterprise-checks-dev-testing.
Succeeded uninstallation for GitHub organization/user: nectarine


Hit max organizations: 15, finishing. 
```