### PR TITLE
Chore: Clean up GitHub Checks app creation instructions

### DIFF
--- a/bulk-install-app/README.md
+++ b/bulk-install-app/README.md
@@ -2,6 +2,7 @@
 
 ## Requirements
 - [python >= 3.6](https://www.python.org/downloads/)
+- [python package requests](https://pypi.org/project/requests/)
 - [python package python-dotenv](https://pypi.org/project/python-dotenv/)
 - [python package beautifulsoup4](https://pypi.org/project/beautifulsoup4/)
 ## Bulk installing a GitHub Checks App across organizations

--- a/github-checks-app/README.md
+++ b/github-checks-app/README.md
@@ -6,14 +6,16 @@
 ## Creating a GitHub Enterprise Server App
 1. Run `python3 github-checks-app-on-enterprise-server.py`
 2. When prompted, input your enterprise server domain
-3. Copy/paste the URL into a browser of your choice, scroll down to click `Create GitHub App`
+3. Copy/paste the URL into a browser of your choice
 4. Take note of the `webhook_secret=<webhook_secret>` in the URL
     ```
     > python3 creating-github-enterprise-server-app.py
     Enter your GitHub Enterprise Server domain name (i.e. github.companyname.com): github.acme.com
     https://github.acme.com...webhook_secret=Z1KPOYifctpzOjfphKj_hqRlZbrDOBG9AU7hgj7iPrk...
     ```
+5. Manually add the `webhook_secret` into the form, since setting webhook secret via query params is no longer supported 
+6. Scroll down to click `Create GitHub App`
    
-5. Once the app is created, you'll be redirected to the settings page of the app. Send us the `webhook_secret` from the URL above, as well as the `app_ID`, `client_ID`, `client_secret`:
+7. Once the app is created, you'll be redirected to the settings page of the app. Send us the `webhook_secret` from the URL above, as well as the `app_name`, `app_ID`, `client_ID`, `client_secret`, `private_key`:
  ![GitHub Checks App Settings](github-checks-app-settings.png)
 

--- a/github-checks-app/github-checks-app-on-enterprise-server.py
+++ b/github-checks-app/github-checks-app-on-enterprise-server.py
@@ -22,14 +22,12 @@ if __name__ == '__main__':
     domain = urlparse(domain if '//' in domain else f'//{domain}').netloc
 
     query_params = {
-        'name': 'BluBracket Checks App',
+        'name': 'HashiCorp Vault Radar App',
         'webhook_secret': token_urlsafe(nbytes=32),
-        'callback_url': f'https://blubracket.blubracket.com/api/github_app/auth?domain={domain}',
-        'webhook_url': f'https://blubracket.blubracket.com/api/github_app/events?domain={domain}',
-        'request_oauth_on_install': True,
+        'webhook_url': f'https://api.hashicorp.cloud/api/github-apps/events?domain={domain}',
         'public': True,
         'webhook_active': True,
-        'url': 'https://blubracket.com',
+        'url': 'https://www.hashicorp.com/',
         'checks': 'write',
         'events[]': ['check_run', 'check_suite', 'pull_request'],
         'pull_requests': 'read',


### PR DESCRIPTION
Few updates - 
- `webhook_secret` can no longer be set via query params, add instructions for manually adding to the form
- No longer using user access tokens and have since switched to using installation access tokens
    - Add instructions for sending over `private_key` after creating the app
    - Remove query params for callback after installation and callback url
- Update callback API endpoint for webhooks